### PR TITLE
security: upload screenshots as 0600 and add CLIPSSH_REMOTE_DIR override

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ export CLIPSSH_HOST=user@myserver
 clipssh
 ```
 
+## Change Upload Directory
+
+Uploads land in `/tmp` by default. Override with `CLIPSSH_REMOTE_DIR`:
+
+```bash
+export CLIPSSH_REMOTE_DIR=~/.cache/clipssh   # must already exist on the remote
+```
+
+Files are written with `umask 077` so they're created as `0600` (owner-readable only) — important on shared hosts where `/tmp` is world-readable by default.
+
 ## Requirements
 
 **macOS:**
@@ -59,7 +69,7 @@ clipssh
 ## How It Works
 
 1. Extracts PNG image from your local clipboard
-2. Uploads to `/tmp/clipboard-<timestamp>.png` on remote host via SSH
+2. Uploads to `$CLIPSSH_REMOTE_DIR/clipboard-<timestamp>.png` (default `/tmp`) on remote host via SSH, with `umask 077` so the file is `0600`
 3. Copies the remote path to your clipboard
 4. You paste the path into Claude Code, OpenCode, or any tool, which reads and displays the image
 

--- a/clipssh
+++ b/clipssh
@@ -26,7 +26,8 @@ usage() {
     echo "  -v, --version  Show version"
     echo ""
     echo "Environment:"
-    echo "  CLIPSSH_HOST   Default remote host"
+    echo "  CLIPSSH_HOST         Default remote host"
+    echo "  CLIPSSH_REMOTE_DIR   Remote directory for uploads (default: /tmp)"
     echo ""
     echo "Example:"
     echo "  clipssh user@myserver"
@@ -108,10 +109,12 @@ if [[ ! -s "$TEMP_FILE" ]]; then
 fi
 
 # Generate remote path
-REMOTE_PATH="/tmp/clipboard-$(date +%s).png"
+REMOTE_DIR="${CLIPSSH_REMOTE_DIR:-/tmp}"
+REMOTE_PATH="$REMOTE_DIR/clipboard-$(date +%s).png"
 
-# Upload via SSH
-if ! cat "$TEMP_FILE" | ssh "$HOST" "cat > $REMOTE_PATH" 2>/dev/null; then
+# Upload via SSH. umask 077 keeps the remote file at mode 0600 so screenshots
+# aren't world-readable on multi-user hosts (default /tmp is shared).
+if ! cat "$TEMP_FILE" | ssh "$HOST" "umask 077 && cat > $REMOTE_PATH" 2>/dev/null; then
     error "Failed to upload to $HOST"
 fi
 


### PR DESCRIPTION
## Why

Default `/tmp` on multi-user remotes is world-readable. Today clipssh writes screenshots with the user's default umask (typically `0644`), so any other local user on the box can read whatever's in the screenshot — terminal output, code, secrets, whatever. Filenames are predictable (`clipboard-<unix-ts>.png`), so they're easy to find too.

## What

- Wrap the remote write in `umask 077` so the file lands as `0600`. No race window, no extra round-trip.
- Add `CLIPSSH_REMOTE_DIR` env var so users can override the upload dir (e.g. `~/.cache/clipssh`) instead of `/tmp`. Default stays `/tmp`.
- README + `--help` document both.

## Compatibility

No breaking changes. Default behavior is unchanged from the user's perspective (same `/tmp/clipboard-<ts>.png` path), just with safer perms. If `CLIPSSH_REMOTE_DIR` is set but doesn't exist on the remote, `ssh ... cat > $REMOTE_PATH` will fail with the existing error path — same UX as a bad host.

## Test plan

- [x] `clipssh user@host` with no env vars → file at `/tmp/clipboard-*.png`, `ls -l` shows `-rw-------`
- [x] `CLIPSSH_REMOTE_DIR=~/.cache/clipssh clipssh user@host` → file at `~/.cache/clipssh/clipboard-*.png`, also `0600`
- [x] `clipssh --help` shows both env vars