### PR TITLE
Prefer wl-clipboard over xclip on Wayland

### DIFF
--- a/clipssh
+++ b/clipssh
@@ -161,10 +161,10 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     fi
     PASTE_CMD="pngpaste"
 elif [[ "$OSTYPE" == "linux"* ]]; then
-    if command -v xclip &> /dev/null; then
-        PASTE_CMD="xclip -selection clipboard -target image/png -o"
-    elif command -v wl-paste &> /dev/null; then
+    if [[ -n "$WAYLAND_DISPLAY" ]] && command -v wl-paste &> /dev/null; then
         PASTE_CMD="wl-paste --type image/png"
+    elif command -v xclip &> /dev/null; then
+        PASTE_CMD="xclip -selection clipboard -target image/png -o"
     else
         error "No clipboard tool found. Install xclip or wl-clipboard"
     fi
@@ -205,10 +205,10 @@ fi
 # Copy path to clipboard
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo -n "$REMOTE_PATH" | pbcopy
+elif [[ -n "$WAYLAND_DISPLAY" ]] && command -v wl-copy &> /dev/null; then
+    echo -n "$REMOTE_PATH" | wl-copy
 elif command -v xclip &> /dev/null; then
     echo -n "$REMOTE_PATH" | xclip -selection clipboard
-elif command -v wl-copy &> /dev/null; then
-    echo -n "$REMOTE_PATH" | wl-copy
 fi
 
 success "Uploaded: $REMOTE_PATH"


### PR DESCRIPTION
On Wayland, xclip can't read the clipboard and just returns empty. Lots of people still have xclip installed as a leftover from X, and clipssh tries it first — so it fails with "No image in clipboard" even when there's clearly an image there. The remote path doesn't get copied back either.

This checks $WAYLAND_DISPLAY and uses wl-paste/wl-copy when it's set, falling back to xclip otherwise. Both spots: reading the screenshot and copying the path back.

Tested on Hyprland with wl-clipboard installed.

(This PR was submitted automatically by Claude Code on my behalf.)