### PR TITLE
feat: add local mode to save screenshots without SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # clipssh
 
-Send clipboard screenshots to remote SSH hosts. Perfect for pasting images into AI coding tools like Claude Code or OpenCode running over SSH.
+Send clipboard screenshots to remote SSH hosts or save locally. Perfect for pasting images into AI coding tools like Claude Code, OpenCode, or local LLMs.
 
 ## The Problem
 
-When using Claude Code, OpenCode (or similar tools) over SSH, you can't paste images from your local clipboard. The remote terminal has no access to your local display server.
+When using Claude Code, OpenCode (or similar tools) over SSH or in local CLI environments, you need a quick way to reference clipboard images as file paths. Over SSH, the remote terminal has no access to your local display server; locally, taking a screenshot and finding its path is tedious.
 
 ## The Solution
 
-`clipssh` extracts the screenshot from your local clipboard, uploads it to the remote server, and copies the file path to your clipboard. Just paste the path into Claude Code, OpenCode, or any terminal tool and it auto-attaches the image.
+`clipssh` extracts the screenshot from your local clipboard, saves it locally or uploads it to a remote server, and copies the file path to your clipboard. Just paste the path into Claude Code, OpenCode, local LLMs, or any terminal tool and it auto-attaches the image.
 
 ## Install
 
@@ -25,6 +25,8 @@ cd clipssh
 
 ## Usage
 
+### Remote SSH Host
+
 ```bash
 # 1. Take a screenshot to the clipboard
 # macOS: Cmd+Shift+Ctrl+4 (select area, copies to clipboard)
@@ -34,6 +36,21 @@ clipssh user@myserver
 
 # 3. Cmd/Ctrl + V in SSH Machine
 # The image will auto-attach
+```
+
+### Local Mode (No SSH)
+
+Save clipboard screenshots directly to your local `/tmp` directory and copy the local file path to your clipboard (ideal for pasting into local LLMs):
+
+```bash
+# Run with 'local' target
+clipssh local
+
+# Or use the short flag
+clipssh -l
+
+# Or run bare clipssh when CLIPSSH_HOST is not set
+clipssh
 ```
 
 ## Custom SSH Port
@@ -103,32 +120,38 @@ clipssh
 
 `CLIPSSH_HOST` also accepts an alias name.
 
-## Change Upload Directory
+## Change Directory
 
-Uploads land in `/tmp` by default. Override with `CLIPSSH_REMOTE_DIR`:
+For remote uploads, files land in `/tmp` by default. Override with `CLIPSSH_REMOTE_DIR`:
 
 ```bash
 export CLIPSSH_REMOTE_DIR=~/.cache/clipssh   # must already exist on the remote
 ```
 
-Files are written with `umask 077` so they're created as `0600` (owner-readable only) — important on shared hosts where `/tmp` is world-readable by default.
+For local saves, files land in `/tmp` by default. Override with `CLIPSSH_LOCAL_DIR`:
+
+```bash
+export CLIPSSH_LOCAL_DIR=~/.local/state/clipssh
+```
+
+Files are written with `umask 077` so they're created as `0600` (owner-readable only) — important on shared hosts or systems where `/tmp` is world-readable by default.
 
 ## Requirements
 
 **macOS:**
 - `pngpaste` - Install with `brew install pngpaste`
-- SSH access to remote host
+- SSH access to remote host (for remote mode)
 
 **Linux:**
 - `xclip` (X11) or `wl-clipboard` (Wayland)
-- SSH access to remote host
+- SSH access to remote host (for remote mode)
 
 ## How It Works
 
 1. Extracts PNG image from your local clipboard
-2. Uploads to `$CLIPSSH_REMOTE_DIR/clipboard-<timestamp>.png` (default `/tmp`) on remote host via SSH, with `umask 077` so the file is `0600`
-3. Copies the remote path to your clipboard
-4. You paste the path into Claude Code, OpenCode, or any tool, which reads and displays the image
+2. Saves to `$CLIPSSH_LOCAL_DIR/clipboard-<timestamp>.png` (default `/tmp`) locally or uploads to `$CLIPSSH_REMOTE_DIR/clipboard-<timestamp>.png` on the remote host via SSH, with `umask 077` so the file is `0600`
+3. Copies the resulting file path to your clipboard
+4. You paste the path into Claude Code, OpenCode, local LLMs, or any tool, which reads and displays the image
 
 ## License
 

--- a/clipssh
+++ b/clipssh
@@ -17,16 +17,17 @@ ALIAS_DIR="$HOME/.clipssh"
 ALIAS_FILE="$ALIAS_DIR/aliases"
 
 usage() {
-    echo "Usage: clipssh [user@host|alias] [options]"
+    echo "Usage: clipssh [user@host|alias|local] [options]"
     echo "       clipssh alias add <name> <user@host>"
     echo "       clipssh alias remove <name>"
     echo "       clipssh alias list"
     echo ""
-    echo "Send clipboard screenshot to remote SSH host and copy path to clipboard."
+    echo "Send clipboard screenshot to remote SSH host (or save locally) and copy path to clipboard."
     echo ""
     echo "Arguments:"
     echo "  user@host    Remote host (default: \$CLIPSSH_HOST)"
     echo "  alias        Saved alias name (resolved from ~/.clipssh/aliases)"
+    echo "  local        Save screenshot locally without SSH"
     echo ""
     echo "Subcommands:"
     echo "  alias add <name> <user@host>  Save a host under a short name"
@@ -34,14 +35,18 @@ usage() {
     echo "  alias list                    Show all saved aliases"
     echo ""
     echo "Options:"
+    echo "  -l, --local    Save screenshot locally without SSH"
     echo "  -h, --help     Show this help"
     echo "  -v, --version  Show version"
     echo ""
     echo "Environment:"
     echo "  CLIPSSH_HOST         Default remote host"
     echo "  CLIPSSH_REMOTE_DIR   Remote directory for uploads (default: /tmp)"
+    echo "  CLIPSSH_LOCAL_DIR    Local directory for saved screenshots (default: /tmp)"
     echo ""
     echo "Example:"
+    echo "  clipssh local"
+    echo "  clipssh -l"
     echo "  clipssh alias add myserver user@myserver.com"
     echo "  clipssh myserver"
     echo "  clipssh user@myserver"
@@ -122,6 +127,19 @@ if [[ "$1" == "alias" ]]; then
     esac
 fi
 
+copy_path_to_clipboard() {
+    local target_path="$1"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo -n "$target_path" | pbcopy
+    elif [[ -n "$WAYLAND_DISPLAY" ]] && command -v wl-copy &> /dev/null; then
+        echo -n "$target_path" | wl-copy
+    elif command -v xclip &> /dev/null; then
+        echo -n "$target_path" | xclip -selection clipboard
+    fi
+}
+
+LOCAL_MODE=false
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -133,32 +151,44 @@ while [[ $# -gt 0 ]]; do
             echo "clipssh $VERSION"
             exit 0
             ;;
+        -l|--local)
+            LOCAL_MODE=true
+            shift
+            ;;
         -*)
             error "Unknown option: $1"
             ;;
         *)
-            HOST="$1"
+            if [[ "$1" == "local" ]]; then
+                LOCAL_MODE=true
+            else
+                HOST="$1"
+            fi
             shift
             ;;
     esac
 done
 
-# Determine host
-HOST="${HOST:-$CLIPSSH_HOST}"
-if [[ -z "$HOST" ]]; then
-    error "No host specified. Use: clipssh user@host or set CLIPSSH_HOST"
+# Determine host or default to local mode
+if [[ "$LOCAL_MODE" != true ]]; then
+    HOST="${HOST:-$CLIPSSH_HOST}"
+    if [[ -z "$HOST" ]]; then
+        LOCAL_MODE=true
+    fi
 fi
 
-# Resolve alias if HOST is a bare name (no user@)
-if [[ "$HOST" != *"@"* ]]; then
-    HOST=$(resolve_alias "$HOST")
-fi
+if [[ "$LOCAL_MODE" != true ]]; then
+    # Resolve alias if HOST is a bare name (no user@)
+    if [[ "$HOST" != *"@"* ]]; then
+        HOST=$(resolve_alias "$HOST")
+    fi
 
-# Extract port if specified in user@host:port format
-SSH_PORT=""
-if [[ "$HOST" =~ ^(.*):([0-9]+)$ && "${BASH_REMATCH[1]}" != *:* ]]; then
-    HOST="${BASH_REMATCH[1]}"
-    SSH_PORT="${BASH_REMATCH[2]}"
+    # Extract port if specified in user@host:port format
+    SSH_PORT=""
+    if [[ "$HOST" =~ ^(.*):([0-9]+)$ && "${BASH_REMATCH[1]}" != *:* ]]; then
+        HOST="${BASH_REMATCH[1]}"
+        SSH_PORT="${BASH_REMATCH[2]}"
+    fi
 fi
 
 # Check OS and clipboard tool
@@ -199,6 +229,20 @@ if [[ ! -s "$TEMP_FILE" ]]; then
     error "Clipboard image is empty"
 fi
 
+# Handle local mode
+if [[ "$LOCAL_MODE" == true ]]; then
+    LOCAL_DIR="${CLIPSSH_LOCAL_DIR:-/tmp}"
+    mkdir -p "$LOCAL_DIR"
+    LOCAL_PATH="$LOCAL_DIR/clipboard-$(date +%s).png"
+
+    (umask 077 && cp "$TEMP_FILE" "$LOCAL_PATH")
+    copy_path_to_clipboard "$LOCAL_PATH"
+
+    success "Saved: $LOCAL_PATH"
+    echo "Path copied to clipboard - paste it directly"
+    exit 0
+fi
+
 # Generate remote path
 REMOTE_DIR="${CLIPSSH_REMOTE_DIR:-/tmp}"
 REMOTE_PATH="$REMOTE_DIR/clipboard-$(date +%s).png"
@@ -216,13 +260,7 @@ if ! cat "$TEMP_FILE" | ssh "${SSH_OPTS[@]}" "$HOST" "umask 077 && cat > $REMOTE
 fi
 
 # Copy path to clipboard
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo -n "$REMOTE_PATH" | pbcopy
-elif [[ -n "$WAYLAND_DISPLAY" ]] && command -v wl-copy &> /dev/null; then
-    echo -n "$REMOTE_PATH" | wl-copy
-elif command -v xclip &> /dev/null; then
-    echo -n "$REMOTE_PATH" | xclip -selection clipboard
-fi
+copy_path_to_clipboard "$REMOTE_PATH"
 
 success "Uploaded: $REMOTE_PATH"
 echo "Path copied to clipboard - paste it directly"


### PR DESCRIPTION
## Overview

This PR adds local mode support to `clipssh`, allowing users to extract clipboard screenshots directly to a local directory (default: `/tmp`) without needing an SSH host. The resulting local path is copied directly to the clipboard, making it effortless to paste image paths into local LLMs, terminal assistants, and local editors.

---

## What Changes

- **Local Mode Invocations**:
  - `clipssh local`: Explicit subcommand to save locally.
  - `clipssh -l` / `clipssh --local`: CLI flag for local mode.
  - Bare `clipssh`: Automatically falls back to local mode when `$CLIPSSH_HOST` is unset.
- **Configurable Local Directory**: Supported via `CLIPSSH_LOCAL_DIR` (defaults to `/tmp`).
- **Unified Clipboard Copy**: Extracted `copy_path_to_clipboard` helper to handle path copying across macOS (`pbcopy`), Wayland (`wl-copy`), and X11 (`xclip`).
- **File Permissions**: Respects `umask 077` (creating files with `0600` permissions), matching remote behavior.
- **Documentation**: Updated `README.md` and CLI `usage` text to document local mode, flags, and environment variables.

---

## Verification

- [x] Tested `clipssh local` on macOS (saves PNG to `/tmp`, copies `/tmp/clipboard-*.png` to clipboard).
- [x] Tested `clipssh -l` and `clipssh --local`.
- [x] Tested bare `clipssh` with `$CLIPSSH_HOST` unset (defaults to local mode).
- [x] Tested custom `CLIPSSH_LOCAL_DIR` override.
- [x] Verified remote SSH invocations (`clipssh user@host`, aliases, `CLIPSSH_HOST`) remain completely unchanged and functional.
- [x] Verified non-image clipboard error handling.